### PR TITLE
Fix for FEI scale bars

### DIFF
--- a/macros/toolsets/EMScaleBarTools.ijm
+++ b/macros/toolsets/EMScaleBarTools.ijm
@@ -13,8 +13,8 @@ Installation:
 
 */
 
-var date = "09/2022"
-var version = 0.3
+var date = "04/2023"
+var version = 0.3.2
 
 //Initialize scale-bar parameters
 var hfac = call("ij.Prefs.get", "sb.hfac", 0.02); // default 0.02


### PR DESCRIPTION
Update `addScalebar()` function in FEI/TFS function, which caused rounding errors on the scale bar length.