### PR TITLE
Hotfix rounding errors

### DIFF
--- a/macros/FEI_Crop_Scalebar.ijm
+++ b/macros/FEI_Crop_Scalebar.ijm
@@ -11,7 +11,7 @@ Installation:
 4) For a help menu select the "?" button and enter the "Help" menu and/or visit the Github page.
 
 * This code is under MIT licence.
-* Author: Lukas Gruenewald, 09/2022, https://github.com/lukmuk/em-scalebartools
+* Author: Lukas Gruenewald, 08/2023, https://github.com/lukmuk/em-scalebartools
 
 */
 
@@ -168,6 +168,16 @@ function addScalebar() {
 	// 1-2-5 series is calculated by repeated multiplication with 2.3, rounded to one significant digit
 	while (scalebarlen < maxscalebarlen) {
 		scalebarlen = round((scalebarlen*2.3)/(Math.pow(10,(floor(Math.log10(abs(scalebarlen*2.3)))))))*(Math.pow(10,(floor(Math.log10(abs(scalebarlen*2.3))))));
+	}
+	
+	// Check for possible rounding errors
+	if(scalebarlen < 1)  {
+		print("Scale bar length in physical units < 1 unit. Possible rounding error.");
+		print("Please DOUBLE-CHECK SCALE BAR LENGTH!");
+		print("Doubling scale bar length until it is at least 1 unit.");
+		print("Before: ", scalebarlen);
+		while(scalebarlen < 1) scalebarlen *= 2;
+		print("After: ", scalebarlen);
 	}
 
 	// Update len variable with found scale-bar length, required for other macros

--- a/macros/toolsets/EMScaleBarTools.ijm
+++ b/macros/toolsets/EMScaleBarTools.ijm
@@ -13,8 +13,8 @@ Installation:
 
 */
 
-var date = "04/2023"
-var version = 0.3.2
+var date = "08/2023"
+var version = 0.3.3
 
 //Initialize scale-bar parameters
 var hfac = call("ij.Prefs.get", "sb.hfac", 0.02); // default 0.02
@@ -595,7 +595,18 @@ function addScalebar() {
 	while (scalebarlen < maxscalebarlen) {
 		scalebarlen = round((scalebarlen*2.3)/(Math.pow(10,(floor(Math.log10(abs(scalebarlen*2.3)))))))*(Math.pow(10,(floor(Math.log10(abs(scalebarlen*2.3))))));
 	}
-
+	
+	// Check for possible rounding errors
+	if(scalebarlen < 1)  {
+		print("Scale bar length in physical units < 1 unit. Possible rounding error.");
+		print("Please DOUBLE-CHECK SCALE BAR LENGTH!");
+		print("Before: ", scalebarlen);
+		while(scalebarlen < 1) scalebarlen *= 2;
+		print("After: ", scalebarlen);
+	}
+	
+	// print(scalebarlen);
+	
 	// Update len variable with found scale-bar length, required for other macros
 	call("ij.Prefs.set", "sb.len", scalebarlen);
 	call("ij.Prefs.set", "sb.height", height); 
@@ -623,6 +634,7 @@ function addScalebar() {
 		run("Duplicate...", "title="+substring(getTitle(), 0, lastIndexOf(getTitle(), '.'))+"_scale-"+vals[index]+unit+".tif");
 		if(auto_rescale) close(name);
 	}
+	
 }
 
 function updateScalebar() {


### PR DESCRIPTION
Again, noticed possibility for rounding errors when the scale bar length is, e.g., 0.5 unit.
Then the scale bar might be falsely generated/shown with 1 unit instead of 0.5 unit for the same length.
This quick fix double the scale bar length until it is at least 1 unit.

Have tested it for a few images where I ran into the problem; hopefully it catches many cases...