### PR TITLE
Fix scale bar length

### DIFF
--- a/macros/FEI_Crop_Scalebar.ijm
+++ b/macros/FEI_Crop_Scalebar.ijm
@@ -174,9 +174,9 @@ function addScalebar() {
 	if(scalebarlen < 1)  {
 		print("Scale bar length in physical units < 1 unit. Possible rounding error.");
 		print("Please DOUBLE-CHECK SCALE BAR LENGTH!");
-		print("Doubling scale bar length until it is at least 1 unit.");
+		print("Setting scale bar to 1 unit.");
 		print("Before: ", scalebarlen);
-		while(scalebarlen < 1) scalebarlen *= 2;
+		if(scalebarlen < 1) scalebarlen = 1;
 		print("After: ", scalebarlen);
 	}
 

--- a/macros/toolsets/EMScaleBarTools.ijm
+++ b/macros/toolsets/EMScaleBarTools.ijm
@@ -600,8 +600,9 @@ function addScalebar() {
 	if(scalebarlen < 1)  {
 		print("Scale bar length in physical units < 1 unit. Possible rounding error.");
 		print("Please DOUBLE-CHECK SCALE BAR LENGTH!");
+		print("Setting scale bar to 1 unit.");
 		print("Before: ", scalebarlen);
-		while(scalebarlen < 1) scalebarlen *= 2;
+		if(scalebarlen < 1) scalebarlen = 1;
 		print("After: ", scalebarlen);
 	}
 	


### PR DESCRIPTION
Better solution for hotfix used in v0.3.3.
Simply set `scalebarlen` to 1 if it is smaller than 1.